### PR TITLE
Add per-user admin menu hiding

### DIFF
--- a/README
+++ b/README
@@ -16,7 +16,7 @@ Evy Add-Ons Theme Storefront เป็นปลั๊กอิน WordPress ท�
 บังคับให้สินค้าที่เกี่ยวข้องที่แสดงผลบนหน้าสินค้าเดี่ยว เป็นสินค้าที่อยู่ในหมวดหมู่เดียวกันกับสินค้าปัจจุบันเท่านั้น
 การปรับแต่งหน้าผู้ใช้และเมนูผู้จัดการร้าน:
 
-เมื่อเปิดใช้งานในหน้า **Settings → Evy Add-Ons** จะมีการลบและล็อกการแก้ไขฟิลด์ Nickname และ Display Name ในโปรไฟล์ผู้ใช้ รวมถึงซ่อนเมนู "แผงควบคุม" และ "รูปลักษณ์" สำหรับผู้ใช้ที่มีบทบาท shop_manager
+เมื่อเปิดใช้งานในหน้า **Settings → Evy Add-Ons** จะมีการลบและล็อกการแก้ไขฟิลด์ Nickname และ Display Name ในโปรไฟล์ผู้ใช้ รวมถึงซ่อนเมนู "แผงควบคุม" และ "รูปลักษณ์" สำหรับผู้ใช้ที่มีบทบาท shop_manager หรือชื่อผู้ใช้ที่ระบุไว้
 การติดตั้ง
 ดาวน์โหลด/สร้างไฟล์ปลั๊กอิน:
 
@@ -60,7 +60,7 @@ Addresses limitations in the Storefront theme regarding cross-category related p
 Ensures that related products shown on single product pages are exclusively from the same category as the current product.
 Admin UX Tweaks:
 
-When enabled from **Settings → Evy Add-Ons**, the plugin removes and locks the Nickname and Display Name fields on user profile pages and hides the Dashboard and Appearance menus for users with the shop_manager role.
+When enabled from **Settings → Evy Add-Ons**, the plugin removes and locks the Nickname and Display Name fields on user profile pages and hides the Dashboard and Appearance menus for shop_manager users or specific usernames you list.
 Installation
 Download/Create Plugin Files:
 


### PR DESCRIPTION
## Summary
- allow specifying user logins whose admin menus will be hidden
- update plugin version to 1.2.0
- document new capability in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844e916927c8332b2976aa6229308c1