### PR TITLE
Fix missing Hidden Menus setting

### DIFF
--- a/evy-add-ons-theme-storefront.php
+++ b/evy-add-ons-theme-storefront.php
@@ -177,6 +177,14 @@ function evy_register_settings() {
         ['label_for' => 'evy_disable_nickname_fields']
     );
 
+    add_settings_field(
+        'evy_hidden_menus_by_user',
+        __('Hidden Menus by User', 'evy-add-ons-storefront'),
+        'evy_field_hidden_menus_by_user',
+        'evy_addons_settings',
+        'evy_settings_section'
+    );
+
 }
 
 function evy_sanitize_csv($value) {


### PR DESCRIPTION
## Summary
- add the `Hidden Menus by User` settings field so the option appears in the admin page

## Testing
- `php -l evy-add-ons-theme-storefront.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68450e8886e8833283cb1912bfbab5b2